### PR TITLE
Turn off second event system

### DIFF
--- a/Assets/_FSVR/Scenes/ForeverSnowland.unity
+++ b/Assets/_FSVR/Scenes/ForeverSnowland.unity
@@ -2735,7 +2735,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 853454013}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
   m_Name: 


### PR DESCRIPTION
To fix the conflict with the 2 event systems in the scene I disabled the second event system that was sitting on the "PointableCanvasModule"

<img width="481" height="327" alt="image" src="https://github.com/user-attachments/assets/73fae4c7-5249-426e-9297-1a7553d2c6c3" />
